### PR TITLE
Create a backwards compatible way to override Raven_Processor sub-class ...

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -199,6 +199,25 @@ Defaults to 1024 characters.
 
 This value is used to truncate message and frame variables. However it is not guarantee that length of whole message will be restricted by this value.
 
+``processors``
+~~~~~~~~~~~~~~~~~
+
+An array of classes to use to process data before it is sent to Sentry. By default, Raven_SanitizeDataProcessor is used
+
+``processorOptions``
+~~~~~~~~~~~~~~~~~
+Options that will be passed on to a setProcessorOptions() function in a Raven_Processor sub-class before that Processor is added to the list of processors used by Raven_Client
+
+An example of overriding the regular expressions in Raven_SanitizeDataProcessor is below:
+
+.. code-block:: php
+
+    'processorOptions' => array(
+        'Raven_SanitizeDataProcessor' => array(
+                    'fields_re' => '/(user_password|user_token|user_secret)/i',
+                    'values_re' => '/^(?:\d[ -]*?){15,16}$/'
+                )
+    )
 
 Providing Request Context
 -------------------------

--- a/lib/Raven/Processor.php
+++ b/lib/Raven/Processor.php
@@ -4,7 +4,7 @@
  *
  * @package raven
  */
-class Raven_Processor
+abstract class Raven_Processor
 {
     public function __construct(Raven_Client $client)
     {
@@ -13,8 +13,8 @@ class Raven_Processor
 
     /**
      * Process and sanitize data, modifying the existing value if necessary.
+     *
+     * @param array $data   Array of log data
      */
-    public function process(&$data)
-    {
-    }
+    abstract public function process(&$data);
 }

--- a/lib/Raven/SanitizeDataProcessor.php
+++ b/lib/Raven/SanitizeDataProcessor.php
@@ -7,31 +7,95 @@
  */
 class Raven_SanitizeDataProcessor extends Raven_Processor
 {
-    static $mask = '********';
-    static $fields_re = '/(authorization|password|passwd|secret|password_confirmation|card_number)/i';
-    static $values_re = '/^(?:\d[ -]*?){13,16}$/';
+    const MASK = '********';
+    const FIELDS_RE = '/(authorization|password|passwd|secret|password_confirmation|card_number)/i';
+    const VALUES_RE = '/^(?:\d[ -]*?){13,16}$/';
 
+    private $client;
+    private $fields_re;
+    private $values_re;
+
+    public function __construct(Raven_Client $client)
+    {
+        $this->client       = $client;
+        $this->fields_re    = self::FIELDS_RE;
+        $this->values_re   = self::VALUES_RE;
+    }
+
+    /**
+     * Override the default processor options
+     *
+     * @param array $options    Associative array of processor options
+     */
+    public function setProcessorOptions(array $options){
+        if( isset($options['fields_re']) ){
+            $this->fields_re = $options['fields_re'];
+        }
+
+        if( isset($options['values_re']) ){
+            $this->values_re = $options['values_re'];
+        }
+    }
+
+    /**
+     * Replace any array values with our mask if the field name or the value matches a respective regex
+     *
+     * @param mixed $item       Associative array value
+     * @param string $key       Associative array key
+     */
     public function sanitize(&$item, $key)
     {
         if (empty($item)) {
             return;
         }
 
-        if (preg_match(self::$values_re, $item)) {
-            $item = self::$mask;
+        if (preg_match($this->values_re, $item)) {
+            $item = self::MASK;
         }
 
         if (empty($key)) {
             return;
         }
 
-        if (preg_match(self::$fields_re, $key)) {
-            $item = self::$mask;
+        if (preg_match($this->fields_re, $key)) {
+            $item = self::MASK;
         }
     }
 
     public function process(&$data)
     {
         array_walk_recursive($data, array($this, 'sanitize'));
+    }
+
+    /**
+     * @return string
+     */
+    public function getFieldsRe()
+    {
+        return $this->fields_re;
+    }
+
+    /**
+     * @param string $fields_re
+     */
+    public function setFieldsRe($fields_re)
+    {
+        $this->fields_re = $fields_re;
+    }
+
+    /**
+     * @return string
+     */
+    public function getValuesRe()
+    {
+        return $this->values_re;
+    }
+
+    /**
+     * @param string $values_re
+     */
+    public function setValuesRe($values_re)
+    {
+        $this->values_re = $values_re;
     }
 }

--- a/test/Raven/Tests/ClientTest.php
+++ b/test/Raven/Tests/ClientTest.php
@@ -381,10 +381,10 @@ class Raven_Tests_ClientTest extends PHPUnit_Framework_TestCase
     public function testDoesRegisterProcessors()
     {
         $client = new Dummy_Raven_Client(array(
-            'processors' => array('Raven_Processor'),
+            'processors' => array('Raven_SanitizeDataProcessor'),
         ));
         $this->assertEquals(count($client->processors), 1);
-        $this->assertTrue($client->processors[0] instanceof Raven_Processor);
+        $this->assertTrue($client->processors[0] instanceof Raven_SanitizeDataProcessor);
     }
 
     public function testProcessDoesCallProcessors()

--- a/test/Raven/Tests/SanitizeDataProcessorTest.php
+++ b/test/Raven/Tests/SanitizeDataProcessorTest.php
@@ -38,15 +38,15 @@ class Raven_Tests_SanitizeDataProcessorTest extends PHPUnit_Framework_TestCase
 
         $vars = $data['sentry.interfaces.Http']['data'];
         $this->assertEquals($vars['foo'], 'bar');
-        $this->assertEquals(Raven_SanitizeDataProcessor::$mask, $vars['password']);
-        $this->assertEquals(Raven_SanitizeDataProcessor::$mask, $vars['the_secret']);
-        $this->assertEquals(Raven_SanitizeDataProcessor::$mask, $vars['a_password_here']);
-        $this->assertEquals(Raven_SanitizeDataProcessor::$mask, $vars['mypasswd']);
-        $this->assertEquals(Raven_SanitizeDataProcessor::$mask, $vars['authorization']);
+        $this->assertEquals(Raven_SanitizeDataProcessor::MASK, $vars['password']);
+        $this->assertEquals(Raven_SanitizeDataProcessor::MASK, $vars['the_secret']);
+        $this->assertEquals(Raven_SanitizeDataProcessor::MASK, $vars['a_password_here']);
+        $this->assertEquals(Raven_SanitizeDataProcessor::MASK, $vars['mypasswd']);
+        $this->assertEquals(Raven_SanitizeDataProcessor::MASK, $vars['authorization']);
 
         $this->markTestIncomplete('Array scrubbing has not been implemented yet.');
 
-        $this->assertEquals(Raven_SanitizeDataProcessor::$mask, $vars['card_number']['0']);
+        $this->assertEquals(Raven_SanitizeDataProcessor::MASK, $vars['card_number']['0']);
     }
 
     public function testDoesFilterCreditCard()
@@ -59,6 +59,118 @@ class Raven_Tests_SanitizeDataProcessorTest extends PHPUnit_Framework_TestCase
         $processor = new Raven_SanitizeDataProcessor($client);
         $processor->process($data);
 
-        $this->assertEquals(Raven_SanitizeDataProcessor::$mask, $data['ccnumba']);
+        $this->assertEquals(Raven_SanitizeDataProcessor::MASK, $data['ccnumba']);
+    }
+
+    /**
+     * @covers setProcessorOptions
+     *
+     */
+    public function testSettingProcessorOptions(){
+        $client     = new Raven_Client();
+        $processor  = new Raven_SanitizeDataProcessor($client);
+
+        $this->assertEquals($processor->getFieldsRe(), '/(authorization|password|passwd|secret|password_confirmation|card_number)/i','got default fields');
+        $this->assertEquals($processor->getValuesRe(),'/^(?:\d[ -]*?){13,16}$/','got default values');
+
+        $options = array(
+            'fields_re' => '/(api_token)/i',
+            'values_re' => '/^(?:\d[ -]*?){15,16}$/'
+        );
+
+        $processor->setProcessorOptions($options);
+
+        $this->assertEquals($processor->getFieldsRe(), '/(api_token)/i','overwrote fields');
+        $this->assertEquals($processor->getValuesRe(), '/^(?:\d[ -]*?){15,16}$/','overwrote values');
+    }
+
+    /**
+     * @dataProvider overrideDataProvider
+     *
+     * @param $processorOptions
+     * @param $client_options
+     * @param $dsn
+     */
+    public function testOverrideOptions($processorOptions, $client_options, $dsn){
+        $client = new Raven_Client($dsn, $client_options);
+        $processor = $client->processors[0];
+
+        $this->assertInstanceOf('Raven_SanitizeDataProcessor', $processor);
+        $this->assertEquals($processor->getFieldsRe(), $processorOptions['Raven_SanitizeDataProcessor']['fields_re'],'overwrote fields');
+        $this->assertEquals($processor->getValuesRe(), $processorOptions['Raven_SanitizeDataProcessor']['values_re'],'overwrote values');
+    }
+
+    /**
+     * @depends testOverrideOptions
+     * @dataProvider overrideDataProvider
+     *
+     * @param $processorOptions
+     * @param $client_options
+     * @param $dsn
+     */
+    public function testOverridenSanitize($processorOptions, $client_options, $dsn){
+        $data = array(
+            'sentry.interfaces.Http' => array(
+                'data' => array(
+                    'foo'               => 'bar',
+                    'password'          => 'hello',
+                    'the_secret'        => 'hello',
+                    'a_password_here'   => 'hello',
+                    'mypasswd'          => 'hello',
+                    'api_token'         => 'nioenio3nrio3jfny89nby9bhr#RML#R',
+                    'authorization'     => 'Basic dXNlcm5hbWU6cGFzc3dvcmQ=',
+                    'card_number'   => array(
+                        '1111111111111111',
+                        '2222',
+                    )
+                ),
+            )
+        );
+
+        $client = new Raven_Client($dsn, $client_options);
+        $processor = $client->processors[0];
+
+        $this->assertInstanceOf('Raven_SanitizeDataProcessor', $processor);
+        $this->assertEquals($processor->getFieldsRe(), $processorOptions['Raven_SanitizeDataProcessor']['fields_re'],'overwrote fields');
+        $this->assertEquals($processor->getValuesRe(), $processorOptions['Raven_SanitizeDataProcessor']['values_re'],'overwrote values');
+
+        $processor->process($data);
+
+        $vars = $data['sentry.interfaces.Http']['data'];
+        $this->assertEquals($vars['foo'], 'bar','did not alter foo');
+        $this->assertEquals($vars['password'], 'hello','did not alter password');
+        $this->assertEquals($vars['the_secret'],'hello','did not alter the_secret');
+        $this->assertEquals($vars['a_password_here'],'hello','did not alter a_password_here');
+        $this->assertEquals($vars['mypasswd'],'hello','did not alter mypasswd');
+        $this->assertEquals($vars['authorization'],'Basic dXNlcm5hbWU6cGFzc3dvcmQ=','did not alter authorization');
+        $this->assertEquals(Raven_SanitizeDataProcessor::MASK, $vars['api_token'],'masked api_token');
+
+        $this->assertEquals(Raven_SanitizeDataProcessor::MASK, $vars['card_number']['0'], 'masked card_number[0]');
+        $this->assertEquals($vars['card_number']['1'], $vars['card_number']['1'],'did not alter card_number[1]');
+    }
+
+    /**
+     * Provides data for testing overriding the processor options
+     *
+     * @return array
+     */
+    public static function overrideDataProvider(){
+        $processorOptions = array(
+            'Raven_SanitizeDataProcessor' => array(
+                'fields_re' => '/(api_token)/i',
+                'values_re' => '/^(?:\d[ -]*?){15,16}$/'
+            )
+        );
+
+        $client_options = array(
+            'processors' => array('Raven_SanitizeDataProcessor'),
+            'processorOptions' => $processorOptions
+        );
+
+        $dsn = 'http://9aaa31f9a05b4e72aaa06aa8157a827a:9aa7aa82a9694a08a1a7589a2a035a9a@sentry.domain.tld/1';
+
+        return array(
+            array($processorOptions, $client_options, $dsn)
+        );
     }
 }


### PR DESCRIPTION
There's probably a more elegant way to do this but I wanted to provide backwards compatibility for those already passing in $options = array('processors'=>array($x));

Create a backwards compatible way to override Raven_Processor sub-class properties so that SanitizeDataProcessor can be modified via $options when creating a new Raven_Client instance:

	lib/Raven/Client.php:
		add PHPDoc comments for many functions
		abstract out setting of processors to setProcessorsFromOptions()
		allow for Raven_Processor->setProcessorOptions() to be called if defined in the Raven_Processor() sub-class
		allow one to set $this->processors with setProcessors()
	lib/Raven/Processor.php:
		make class abstract as it has no functionality
		make process abstract to ensure that sub-classes implement it
	lib/Raven/SanitizeDataProcessor.php:
		convert static $mask,$fields_re,$values_re to const MASK,FIELDS_RE,VALUES_RE
		allow overriding $this->fields_re and $this->values_re with setProcessorOptions()
		add getters/setters for $fields_re and $values_re class variables
	test/Raven/Tests/ClientTest.php:
		Use processor Raven_SanitizeDataProcessor in testDoesRegisterProcessors() now that Raven_Processor is abstract
	test/Raven/Tests/SanitizeDataProcessorTest.php:
		Add testSettingProcessorOptions() to test new setProcessorOptions() function
		Add testOverrideOptions() to test setProcessorOptions() when called via __construct of Raven_Client
		Add testOverridenSanitize() to test that overriding sanitizers work
	README.rst:
		Add processors and processorOptions to docs