### PR TITLE
- adding option for forcing ipv4

### DIFF
--- a/lib/Raven/Client.php
+++ b/lib/Raven/Client.php
@@ -69,6 +69,7 @@ class Raven_Client
         $this->send_callback = Raven_Util::get($options, 'send_callback', null);
         $this->curl_method = Raven_Util::get($options, 'curl_method', 'sync');
         $this->curl_path = Raven_Util::get($options, 'curl_path', 'curl');
+        $this->curl_ipv4 = Raven_util::get($options, 'curl_ipv4', false);
         $this->ca_cert = Raven_util::get($options, 'ca_cert', $this->get_default_ca_cert());
 		$this->curl_ssl_version = Raven_Util::get($options, 'curl_ssl_version');
 
@@ -551,7 +552,10 @@ class Raven_Client
         }
         if ($this->curl_ssl_version) {
 	        $options[CURLOPT_SSLVERSION] = $this->curl_ssl_version;
-        }        
+        }
+        if ($this->curl_ipv4) {
+            $options[CURLOPT_IPRESOLVE] = CURL_IPRESOLVE_V4;
+        }
         if (defined('CURLOPT_TIMEOUT_MS')) {
             // MS is available in curl >= 7.16.2
             $timeout = max(1, ceil(1000 * $this->timeout));

--- a/lib/Raven/Client.php
+++ b/lib/Raven/Client.php
@@ -69,7 +69,7 @@ class Raven_Client
         $this->send_callback = Raven_Util::get($options, 'send_callback', null);
         $this->curl_method = Raven_Util::get($options, 'curl_method', 'sync');
         $this->curl_path = Raven_Util::get($options, 'curl_path', 'curl');
-        $this->curl_ipv4 = Raven_util::get($options, 'curl_ipv4', false);
+        $this->curl_ipv4 = Raven_util::get($options, 'curl_ipv4', true);
         $this->ca_cert = Raven_util::get($options, 'ca_cert', $this->get_default_ca_cert());
 		$this->curl_ssl_version = Raven_Util::get($options, 'curl_ssl_version');
 


### PR DESCRIPTION
Was having problem with timeout when sending message. Found that it was due to curl using ipv6. 
Forcing use of ip v4 resolving like this:

      curl_setopt($curl, CURLOPT_IPRESOLVE, CURL_IPRESOLVE_V4 );

near line 606-610 in Client.php, just before:

        $options = $this->get_curl_options();
        $ca_cert = $options[CURLOPT_CAINFO];
        unset($options[CURLOPT_CAINFO]);
        curl_setopt_array($curl, $options);
        curl_exec($curl);

fixed the problem. But it is more elegant to use an option for this, like:

       $client = new Raven_Client('https://.....',array('curl_ipv4'=>true));
