### PR TITLE
Handle empty HTTP_HOST values

### DIFF
--- a/lib/Raven/Client.php
+++ b/lib/Raven/Client.php
@@ -780,7 +780,12 @@ class Raven_Client
         $schema = (!empty($_SERVER['HTTPS']) && $_SERVER['HTTPS'] !== 'off'
             || $_SERVER['SERVER_PORT'] == 443) ? "https://" : "http://";
 
-        return $schema . $_SERVER['HTTP_HOST'] . $_SERVER['REQUEST_URI'];
+        // HTTP_HOST is a client-supplied header that is optional in HTTP 1.0
+        $host = (!empty($_SERVER['HTTP_HOST']) ? $_SERVER['HTTP_HOST']
+            : (!empty($_SERVER['LOCAL_ADDR'])  ? $_SERVER['LOCAL_ADDR']
+            : (!empty($_SERVER['SERVER_ADDR']) ? $_SERVER['SERVER_ADDR'] : '')));
+
+        return $schema . $host . $_SERVER['REQUEST_URI'];
     }
 
     /**


### PR DESCRIPTION
The `Host` HTTP header is optional in HTTP 1.0 and can therefore be empty, meaning the current code raised some `Notice: Undefined index: HTTP_HOST` errors on my installation. I adjusted `get_current_url()` to fall back on `LOCAL_ADDR` (IIS) or `SERVER_ADDR` if `HTTP_HOST` is empty.