### PR TITLE
sanitize $_SERVER['PHP_AUTH_PW']

### DIFF
--- a/lib/Raven/SanitizeDataProcessor.php
+++ b/lib/Raven/SanitizeDataProcessor.php
@@ -8,7 +8,7 @@
 class Raven_SanitizeDataProcessor extends Raven_Processor
 {
     const MASK = '********';
-    const FIELDS_RE = '/(authorization|password|passwd|secret|password_confirmation|card_number)/i';
+    const FIELDS_RE = '/(authorization|password|passwd|secret|password_confirmation|card_number|auth_pw)/i';
     const VALUES_RE = '/^(?:\d[ -]*?){13,16}$/';
 
     private $client;


### PR DESCRIPTION
The http basic auth credentials are not sanitized in the _SERVER array.
