### PR TITLE
Pass the return value of the original error handler on

### DIFF
--- a/lib/Raven/ErrorHandler.php
+++ b/lib/Raven/ErrorHandler.php
@@ -59,7 +59,7 @@ class Raven_ErrorHandler
         }
 
         if ($this->call_existing_error_handler && $this->old_error_handler) {
-            call_user_func($this->old_error_handler, $code, $message, $file, $line, $context);
+            return call_user_func($this->old_error_handler, $code, $message, $file, $line, $context);
         }
     }
 


### PR DESCRIPTION
As specified at http://php.net/manual/en/function.set-error-handler.php,
PHP reacts differently whether false is returned or not. This gives the
original error handler the possibility to influence this value.