### PR TITLE
Fix: Remove bin-dir configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,3 @@
 package.xml
 /vendor
 .idea
-bin/phpunit

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ develop:
 	make setup-git
 
 test:
-	vendor/phpunit/phpunit/phpunit.php
+	vendor/bin/phpunit
 
 setup-git:
 	git config branch.autosetuprebase always

--- a/README.rst
+++ b/README.rst
@@ -262,7 +262,7 @@ You may now use phpunit :
 
 ::
 
-    $ bin/phpunit
+    $ vendor/bin/phpunit
 
 
 

--- a/composer.json
+++ b/composer.json
@@ -20,9 +20,6 @@
     "bin": [
         "bin/raven"
     ],
-    "config": {
-        "bin-dir": "bin"
-    },
     "autoload": {
         "psr-0" : {
             "Raven_" : "lib/"


### PR DESCRIPTION
This PR

* [x] removes the useless `bin-dir` configuration

See https://getcomposer.org/doc/04-schema.md#config.

> `bin-dir`: Defaults to `vendor/bin`. If a project includes binaries, they will be symlinked into this directory.

:bulb: Leaving it to the default value has the advantage that you don't need to add rules to `.gitignore`, as the otherwise configured directory is the same directory in which the `raven` binary is provided in.