### PR TITLE
Fix: Use the same version of phpunit/phpunit on Travis as required

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,10 +6,16 @@ php:
   - 5.5
   - 5.6
   - hhvm
- 
+
 matrix:
     allow_failures:
         - php: hhvm
+
+install:
+  - composer install
+
+script:
+  - bin/phpunit --configuration phpunit.xml.dist
 
 notifications:
   irc:

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,10 +12,10 @@ matrix:
         - php: hhvm
 
 install:
-  - composer install
+  - if [[ $TRAVIS_PHP_VERSION != "5.2" ]]; then composer install; fi
 
 script:
-  - bin/phpunit --configuration phpunit.xml.dist
+  - if [[ $TRAVIS_PHP_VERSION != "5.2" ]]; then bin/phpunit; else phpunit; fi
 
 notifications:
   irc:


### PR DESCRIPTION
This PR updates `.travis.yml` 

* [x] to install the dependencies as required in `composer.json` in the `install` section
* [x] to run the required version of `phpunit/phpunit` in the `script` section
* [x] falls back to using the pre-installed version of `phpunit/phpunit` when running on PHP5.2

:bulb: Using the same version decreases the risk of unexpected results because of using different versions locally and on Travis. The current version used on Travis is `4.5.0` (see https://travis-ci.org/getsentry/raven-php/jobs/61914157#L97), the currently required version is `3.7.*`.

Related to #201.