### PR TITLE
Enhancement: Use php-cs-fixer to maintain PSR-2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 package.xml
 /vendor
 .idea
+.php_cs.cache

--- a/.php_cs
+++ b/.php_cs
@@ -1,0 +1,12 @@
+<?php
+
+$finder = Symfony\CS\Finder\DefaultFinder::create()
+    ->in(__DIR__)
+;
+
+return Symfony\CS\Config\Config::create()
+    ->setUsingCache(true)
+    ->setUsingLinter(true)
+    ->level(Symfony\CS\FixerInterface::PSR2_LEVEL)
+    ->finder($finder)
+;

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,4 +17,5 @@ install:
   - if [[ $TRAVIS_PHP_VERSION != "5.2" ]]; then composer install; fi
 
 script:
+  - if [[ $TRAVIS_PHP_VERSION != "5.2" ]]; then vendor/bin/php-cs-fixer fix --config-file=.php_cs --verbose --diff --dry-run; fi
   - if [[ $TRAVIS_PHP_VERSION != "5.2" ]]; then vendor/bin/phpunit; else phpunit; fi

--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,12 @@ develop:
 	composer install --dev
 	make setup-git
 
+cs:
+	vendor/bin/php-cs-fixer fix --config-file=.php_cs --verbose --diff
+
+cs-dry-run:
+	vendor/bin/php-cs-fixer fix --config-file=.php_cs --verbose --diff --dry-run
+
 test:
 	vendor/bin/phpunit
 

--- a/composer.json
+++ b/composer.json
@@ -12,6 +12,7 @@
         }
     ],
     "require-dev": {
+        "fabpot/php-cs-fixer": "^1.8.0",
         "phpunit/phpunit": "^4.6.6"
     },
     "require": {

--- a/lib/Raven/Client.php
+++ b/lib/Raven/Client.php
@@ -28,10 +28,10 @@ class Raven_Client
 
     const MESSAGE_LIMIT = 1024;
 
-    var $severity_map;
-    var $extra_data;
+    public $severity_map;
+    public $extra_data;
 
-    var $store_errors_for_bulk_send = false;
+    public $store_errors_for_bulk_send = false;
 
     public function __construct($options_or_dsn=null, $options=array())
     {
@@ -63,7 +63,7 @@ class Raven_Client
         $this->timeout = Raven_Util::get($options, 'timeout', 2);
         $this->message_limit = Raven_Util::get($options, 'message_limit', self::MESSAGE_LIMIT);
         $this->exclude = Raven_Util::get($options, 'exclude', array());
-        $this->severity_map = NULL;
+        $this->severity_map = null;
         $this->shift_vars = (bool) Raven_Util::get($options, 'shift_vars', true);
         $this->http_proxy = Raven_Util::get($options, 'http_proxy');
         $this->extra_data = Raven_Util::get($options, 'extra', array());
@@ -73,7 +73,7 @@ class Raven_Client
         $this->curl_ipv4 = Raven_util::get($options, 'curl_ipv4', true);
         $this->ca_cert = Raven_util::get($options, 'ca_cert', $this->get_default_ca_cert());
         $this->verify_ssl = Raven_util::get($options, 'verify_ssl', true);
-		$this->curl_ssl_version = Raven_Util::get($options, 'curl_ssl_version');
+        $this->curl_ssl_version = Raven_Util::get($options, 'curl_ssl_version');
 
         $this->processors = $this->setProcessorsFromOptions($options);
 
@@ -100,13 +100,14 @@ class Raven_Client
      * @param $options
      * @return array
      */
-    public function setProcessorsFromOptions($options){
+    public function setProcessorsFromOptions($options)
+    {
         $processors = array();
         foreach (Raven_util::get($options, 'processors', self::getDefaultProcessors()) as $processor) {
             $new_processor = new $processor($this);
 
-            if( isset($options['processorOptions']) && is_array($options['processorOptions']) ){
-                if( isset($options['processorOptions'][$processor]) && method_exists($processor, 'setProcessorOptions') ){
+            if (isset($options['processorOptions']) && is_array($options['processorOptions'])) {
+                if (isset($options['processorOptions'][$processor]) && method_exists($processor, 'setProcessorOptions')) {
                     $new_processor->setProcessorOptions($options['processorOptions'][$processor]);
                 }
             }
@@ -205,7 +206,7 @@ class Raven_Client
 
         if ($level_or_options === null) {
             $data = array();
-        } else if (!is_array($level_or_options)) {
+        } elseif (!is_array($level_or_options)) {
             $data = array(
                 'level' => $level_or_options,
             );
@@ -280,7 +281,6 @@ class Raven_Client
             );
 
             $exceptions[] = $exc_data;
-
         } while ($has_chained_exceptions && $exc = $exc->getPrevious());
 
         $data['message'] = $message;
@@ -407,11 +407,21 @@ class Raven_Client
 
     public function capture($data, $stack, $vars = null)
     {
-        if (!isset($data['timestamp'])) $data['timestamp'] = gmdate('Y-m-d\TH:i:s\Z');
-        if (!isset($data['level'])) $data['level'] = self::ERROR;
-        if (!isset($data['tags'])) $data['tags'] = array();
-        if (!isset($data['extra'])) $data['extra'] = array();
-        if (!isset($data['event_id'])) $data['event_id'] = $this->uuid4();
+        if (!isset($data['timestamp'])) {
+            $data['timestamp'] = gmdate('Y-m-d\TH:i:s\Z');
+        }
+        if (!isset($data['level'])) {
+            $data['level'] = self::ERROR;
+        }
+        if (!isset($data['tags'])) {
+            $data['tags'] = array();
+        }
+        if (!isset($data['extra'])) {
+            $data['extra'] = array();
+        }
+        if (!isset($data['event_id'])) {
+            $data['event_id'] = $this->uuid4();
+        }
 
         if (isset($data['message'])) {
             $data['message'] = substr($data['message'], 0, $this->message_limit);
@@ -439,7 +449,7 @@ class Raven_Client
             $this->context->extra,
             $data['extra']);
 
-        if ((!$stack && $this->auto_log_stacks) || $stack === True) {
+        if ((!$stack && $this->auto_log_stacks) || $stack === true) {
             $stack = debug_backtrace();
 
             // Drop last stack
@@ -464,10 +474,10 @@ class Raven_Client
         $this->sanitize($data);
         $this->process($data);
 
-        if(!$this->store_errors_for_bulk_send){
+        if (!$this->store_errors_for_bulk_send) {
             $this->send($data);
-        }else{
-            if(empty($this->error_data)){
+        } else {
+            if (empty($this->error_data)) {
                 $this->error_data = array();
             }
             $this->error_data[] = $data;
@@ -498,14 +508,15 @@ class Raven_Client
         }
     }
 
-    public function sendUnsentErrors(){
-        if(!empty($this->error_data)){
-            foreach($this->error_data as $data){
+    public function sendUnsentErrors()
+    {
+        if (!empty($this->error_data)) {
+            foreach ($this->error_data as $data) {
                 $this->send($data);
             }
             unset($this->error_data);
         }
-        if($this->store_errors_for_bulk_send){
+        if ($this->store_errors_for_bulk_send) {
             //in case an error occurs after this is called, on shutdown, send any new errors.
             $this->store_errors_for_bulk_send = !defined('RAVEN_CLIENT_END_REACHED');
         }
@@ -563,8 +574,7 @@ class Raven_Client
 
         if ($parts['scheme'] === 'udp') {
             $this->send_udp($parts['netloc'], $data, $headers['X-Sentry-Auth']);
-        }
-        else {
+        } else {
             $this->send_http($url, $data, $headers);
         }
     }
@@ -586,7 +596,8 @@ class Raven_Client
         socket_close($sock);
     }
 
-    protected function get_default_ca_cert() {
+    protected function get_default_ca_cert()
+    {
         return dirname(__FILE__) . DIRECTORY_SEPARATOR . 'data' . DIRECTORY_SEPARATOR . 'cacert.pem';
     }
 
@@ -603,7 +614,7 @@ class Raven_Client
             $options[CURLOPT_PROXY] = $this->http_proxy;
         }
         if ($this->curl_ssl_version) {
-	        $options[CURLOPT_SSLVERSION] = $this->curl_ssl_version;
+            $options[CURLOPT_SSLVERSION] = $this->curl_ssl_version;
         }
         if ($this->curl_ipv4) {
             $options[CURLOPT_IPRESOLVE] = CURL_IPRESOLVE_V4;
@@ -648,7 +659,8 @@ class Raven_Client
      * @param array     $headers    Associative array of headers
      * @return bool
      */
-    private function send_http_asynchronous_curl_exec($url, $data, $headers) {
+    private function send_http_asynchronous_curl_exec($url, $data, $headers)
+    {
         // TODO(dcramer): support ca_cert
         $cmd = $this->curl_path.' -X POST ';
         foreach ($headers as $key => $value) {
@@ -750,22 +762,22 @@ class Raven_Client
     {
         $uuid = sprintf('%04x%04x-%04x-%04x-%04x-%04x%04x%04x',
             // 32 bits for "time_low"
-            mt_rand( 0, 0xffff ), mt_rand( 0, 0xffff ),
+            mt_rand(0, 0xffff), mt_rand(0, 0xffff),
 
             // 16 bits for "time_mid"
-            mt_rand( 0, 0xffff ),
+            mt_rand(0, 0xffff),
 
             // 16 bits for "time_hi_and_version",
             // four most significant bits holds version number 4
-            mt_rand( 0, 0x0fff ) | 0x4000,
+            mt_rand(0, 0x0fff) | 0x4000,
 
             // 16 bits, 8 bits for "clk_seq_hi_res",
             // 8 bits for "clk_seq_low",
             // two most significant bits holds zero and one for variant DCE1.1
-            mt_rand( 0, 0x3fff ) | 0x8000,
+            mt_rand(0, 0x3fff) | 0x8000,
 
             // 48 bits for "node"
-            mt_rand( 0, 0xffff ), mt_rand( 0, 0xffff ), mt_rand( 0, 0xffff )
+            mt_rand(0, 0xffff), mt_rand(0, 0xffff), mt_rand(0, 0xffff)
         );
 
         return str_replace('-', '', $uuid);
@@ -815,7 +827,8 @@ class Raven_Client
      * @param string $severity  PHP E_$x error constant
      * @return string           Sentry log level group
      */
-    public function translateSeverity($severity) {
+    public function translateSeverity($severity)
+    {
         if (is_array($this->severity_map) && isset($this->severity_map[$severity])) {
             return $this->severity_map[$severity];
         }
@@ -835,7 +848,7 @@ class Raven_Client
             case E_RECOVERABLE_ERROR:  return Raven_Client::ERROR;
         }
         if (version_compare(PHP_VERSION, '5.3.0', '>=')) {
-          switch ($severity) {
+            switch ($severity) {
             case E_DEPRECATED:         return Raven_Client::WARN;
             case E_USER_DEPRECATED:    return Raven_Client::WARN;
           }
@@ -849,7 +862,8 @@ class Raven_Client
      *
      * @param array $map
      */
-    public function registerSeverityMap($map) {
+    public function registerSeverityMap($map)
+    {
         $this->severity_map = $map;
     }
 
@@ -860,7 +874,8 @@ class Raven_Client
      * @param string|null $email    User's email
      * @param array $data           Additional user data
      */
-    public function set_user_data($id, $email=null, $data=array()) {
+    public function set_user_data($id, $email=null, $data=array())
+    {
         $this->user_context(array_merge(array(
             'id'    => $id,
             'email' => $email,
@@ -872,7 +887,8 @@ class Raven_Client
      *
      * @param array $data   Associative array of user data
      */
-    public function user_context($data) {
+    public function user_context($data)
+    {
         $this->context->user = $data;
     }
 
@@ -881,7 +897,8 @@ class Raven_Client
      *
      * @param array $data   Associative array of tags
      */
-    public function tags_context($data) {
+    public function tags_context($data)
+    {
         $this->context->tags = array_merge($this->context->tags, $data);
     }
 
@@ -890,14 +907,16 @@ class Raven_Client
      *
      * @param array $data   Associative array of extra data
      */
-    public function extra_context($data) {
+    public function extra_context($data)
+    {
         $this->context->extra = array_merge($this->context->extra, $data);
     }
 
     /**
      * @param array $processors
      */
-    public function setProcessors(array $processors){
+    public function setProcessors(array $processors)
+    {
         $this->processors = $processors;
     }
 }

--- a/lib/Raven/CurlHandler.php
+++ b/lib/Raven/CurlHandler.php
@@ -69,9 +69,9 @@ class Raven_CurlHandler
 
     public function join($timeout=null)
     {
-    	if (!isset($timeout)) {
-    		$timeout = $this->join_timeout;
-    	}
+        if (!isset($timeout)) {
+            $timeout = $this->join_timeout;
+        }
         $start = time();
         do {
             $this->select();
@@ -94,8 +94,7 @@ class Raven_CurlHandler
                 do {
                     $mrc = curl_multi_exec($this->multi_handle, $active);
                 } while ($mrc == CURLM_CALL_MULTI_PERFORM);
-            }
-            else {
+            } else {
                 return;
             }
         }

--- a/lib/Raven/ErrorHandler.php
+++ b/lib/Raven/ErrorHandler.php
@@ -54,8 +54,8 @@ class Raven_ErrorHandler
     public function handleError($code, $message, $file = '', $line = 0, $context=array())
     {
         if ($this->error_types & $code & error_reporting()) {
-          $e = new ErrorException($message, 0, $code, $file, $line);
-          $this->handleException($e, true, $context);
+            $e = new ErrorException($message, 0, $code, $file, $line);
+            $this->handleException($e, true, $context);
         }
 
         if ($this->call_existing_error_handler) {
@@ -106,7 +106,8 @@ class Raven_ErrorHandler
         $this->reservedMemory = str_repeat('x', 1024 * $reservedMemorySize);
     }
 
-    public function detectShutdown() {
+    public function detectShutdown()
+    {
         if (!defined('RAVEN_CLIENT_END_REACHED')) {
             define('RAVEN_CLIENT_END_REACHED', true);
         }

--- a/lib/Raven/SanitizeDataProcessor.php
+++ b/lib/Raven/SanitizeDataProcessor.php
@@ -27,12 +27,13 @@ class Raven_SanitizeDataProcessor extends Raven_Processor
      *
      * @param array $options    Associative array of processor options
      */
-    public function setProcessorOptions(array $options){
-        if( isset($options['fields_re']) ){
+    public function setProcessorOptions(array $options)
+    {
+        if (isset($options['fields_re'])) {
             $this->fields_re = $options['fields_re'];
         }
 
-        if( isset($options['values_re']) ){
+        if (isset($options['values_re'])) {
             $this->values_re = $options['values_re'];
         }
     }

--- a/lib/Raven/Stacktrace.php
+++ b/lib/Raven/Stacktrace.php
@@ -116,7 +116,6 @@ class Raven_Stacktrace
             $i++;
         }
         return $args;
-
     }
 
     public static function get_frame_context($frame, $frame_arg_limit = Raven_Client::MESSAGE_LIMIT)
@@ -172,11 +171,11 @@ class Raven_Stacktrace
             if (isset($params[$i])) {
                 // Assign the argument by the parameter name
                 if (is_array($arg)) {
-                  foreach ($arg as $key => $value) {
-                    if (is_string($value) || is_numeric($value)) {
-                      $arg[$key] = substr($value, 0, $frame_arg_limit);
+                    foreach ($arg as $key => $value) {
+                        if (is_string($value) || is_numeric($value)) {
+                            $arg[$key] = substr($value, 0, $frame_arg_limit);
+                        }
                     }
-                  }
                 }
                 $args[$params[$i]->name] = $arg;
             } else {
@@ -243,7 +242,7 @@ class Raven_Stacktrace
                     break;
                 }
                 $file->next();
-             }
+            }
         } catch (RuntimeException $exc) {
             return $frame;
         }

--- a/test/Raven/Tests/ClientTest.php
+++ b/test/Raven/Tests/ClientTest.php
@@ -319,10 +319,10 @@ class Raven_Tests_ClientTest extends PHPUnit_Framework_TestCase
         $this->assertEquals(count($exc['values']), 2);
         $this->assertEquals($exc['values'][0]['value'], 'Foo bar');
         $this->assertEquals($exc['values'][1]['value'], 'Child exc');
-
     }
 
-    public function testCaptureExceptionDifferentLevelsInChainedExceptionsBug() {
+    public function testCaptureExceptionDifferentLevelsInChainedExceptionsBug()
+    {
         if (version_compare(PHP_VERSION, '5.3.0', '<')) {
             $this->markTestSkipped('PHP 5.3 required for chained exceptions.');
         }
@@ -418,7 +418,8 @@ class Raven_Tests_ClientTest extends PHPUnit_Framework_TestCase
         $this->assertTrue(in_array('Raven_SanitizeDataProcessor', $defaults));
     }
 
-    public function testGetDefaultData() {
+    public function testGetDefaultData()
+    {
         $client = new Dummy_Raven_Client();
         $expected = array(
             'platform' => 'php',
@@ -495,7 +496,8 @@ class Raven_Tests_ClientTest extends PHPUnit_Framework_TestCase
         $this->assertEquals($expected, $client->get_http_data());
     }
 
-    public function testGetUserDataWithSetUser() {
+    public function testGetUserDataWithSetUser()
+    {
         $client = new Dummy_Raven_Client();
 
         $id = 'unique_id';
@@ -518,7 +520,8 @@ class Raven_Tests_ClientTest extends PHPUnit_Framework_TestCase
         $this->assertEquals($expected, $client->get_user_data());
     }
 
-    public function testGetUserDataWithNoUser() {
+    public function testGetUserDataWithNoUser()
+    {
         $client = new Dummy_Raven_Client();
 
         $expected = array(
@@ -529,7 +532,8 @@ class Raven_Tests_ClientTest extends PHPUnit_Framework_TestCase
         $this->assertEquals($expected, $client->get_user_data());
     }
 
-    public function testGetAuthHeader() {
+    public function testGetAuthHeader()
+    {
         $client = new Dummy_Raven_Client();
 
         $clientstring = 'raven-php/test';
@@ -593,19 +597,20 @@ class Raven_Tests_ClientTest extends PHPUnit_Framework_TestCase
         ), $event['extra']);
     }
 
-    public function cb1($data) {
+    public function cb1($data)
+    {
         $this->assertEquals('test', $data['message']);
         return false;
     }
 
-    public function cb2($data) {
+    public function cb2($data)
+    {
         $this->assertEquals('test', $data['message']);
         return true;
     }
 
     public function testSendCallback()
     {
-
         $client = new Dummy_Raven_Client(array('send_callback' => array($this, 'cb1')));
         $client->captureMessage('test');
         $events = $client->getSentEvents();

--- a/test/Raven/Tests/SanitizeDataProcessorTest.php
+++ b/test/Raven/Tests/SanitizeDataProcessorTest.php
@@ -66,12 +66,13 @@ class Raven_Tests_SanitizeDataProcessorTest extends PHPUnit_Framework_TestCase
      * @covers setProcessorOptions
      *
      */
-    public function testSettingProcessorOptions(){
+    public function testSettingProcessorOptions()
+    {
         $client     = new Raven_Client();
         $processor  = new Raven_SanitizeDataProcessor($client);
 
-        $this->assertEquals($processor->getFieldsRe(), '/(authorization|password|passwd|secret|password_confirmation|card_number|auth_pw)/i','got default fields');
-        $this->assertEquals($processor->getValuesRe(),'/^(?:\d[ -]*?){13,16}$/','got default values');
+        $this->assertEquals($processor->getFieldsRe(), '/(authorization|password|passwd|secret|password_confirmation|card_number|auth_pw)/i', 'got default fields');
+        $this->assertEquals($processor->getValuesRe(), '/^(?:\d[ -]*?){13,16}$/', 'got default values');
 
         $options = array(
             'fields_re' => '/(api_token)/i',
@@ -80,8 +81,8 @@ class Raven_Tests_SanitizeDataProcessorTest extends PHPUnit_Framework_TestCase
 
         $processor->setProcessorOptions($options);
 
-        $this->assertEquals($processor->getFieldsRe(), '/(api_token)/i','overwrote fields');
-        $this->assertEquals($processor->getValuesRe(), '/^(?:\d[ -]*?){15,16}$/','overwrote values');
+        $this->assertEquals($processor->getFieldsRe(), '/(api_token)/i', 'overwrote fields');
+        $this->assertEquals($processor->getValuesRe(), '/^(?:\d[ -]*?){15,16}$/', 'overwrote values');
     }
 
     /**
@@ -91,13 +92,14 @@ class Raven_Tests_SanitizeDataProcessorTest extends PHPUnit_Framework_TestCase
      * @param $client_options
      * @param $dsn
      */
-    public function testOverrideOptions($processorOptions, $client_options, $dsn){
+    public function testOverrideOptions($processorOptions, $client_options, $dsn)
+    {
         $client = new Raven_Client($dsn, $client_options);
         $processor = $client->processors[0];
 
         $this->assertInstanceOf('Raven_SanitizeDataProcessor', $processor);
-        $this->assertEquals($processor->getFieldsRe(), $processorOptions['Raven_SanitizeDataProcessor']['fields_re'],'overwrote fields');
-        $this->assertEquals($processor->getValuesRe(), $processorOptions['Raven_SanitizeDataProcessor']['values_re'],'overwrote values');
+        $this->assertEquals($processor->getFieldsRe(), $processorOptions['Raven_SanitizeDataProcessor']['fields_re'], 'overwrote fields');
+        $this->assertEquals($processor->getValuesRe(), $processorOptions['Raven_SanitizeDataProcessor']['values_re'], 'overwrote values');
     }
 
     /**
@@ -108,7 +110,8 @@ class Raven_Tests_SanitizeDataProcessorTest extends PHPUnit_Framework_TestCase
      * @param $client_options
      * @param $dsn
      */
-    public function testOverridenSanitize($processorOptions, $client_options, $dsn){
+    public function testOverridenSanitize($processorOptions, $client_options, $dsn)
+    {
         $data = array(
             'sentry.interfaces.Http' => array(
                 'data' => array(
@@ -131,22 +134,22 @@ class Raven_Tests_SanitizeDataProcessorTest extends PHPUnit_Framework_TestCase
         $processor = $client->processors[0];
 
         $this->assertInstanceOf('Raven_SanitizeDataProcessor', $processor);
-        $this->assertEquals($processor->getFieldsRe(), $processorOptions['Raven_SanitizeDataProcessor']['fields_re'],'overwrote fields');
-        $this->assertEquals($processor->getValuesRe(), $processorOptions['Raven_SanitizeDataProcessor']['values_re'],'overwrote values');
+        $this->assertEquals($processor->getFieldsRe(), $processorOptions['Raven_SanitizeDataProcessor']['fields_re'], 'overwrote fields');
+        $this->assertEquals($processor->getValuesRe(), $processorOptions['Raven_SanitizeDataProcessor']['values_re'], 'overwrote values');
 
         $processor->process($data);
 
         $vars = $data['sentry.interfaces.Http']['data'];
-        $this->assertEquals($vars['foo'], 'bar','did not alter foo');
-        $this->assertEquals($vars['password'], 'hello','did not alter password');
-        $this->assertEquals($vars['the_secret'],'hello','did not alter the_secret');
-        $this->assertEquals($vars['a_password_here'],'hello','did not alter a_password_here');
-        $this->assertEquals($vars['mypasswd'],'hello','did not alter mypasswd');
-        $this->assertEquals($vars['authorization'],'Basic dXNlcm5hbWU6cGFzc3dvcmQ=','did not alter authorization');
-        $this->assertEquals(Raven_SanitizeDataProcessor::MASK, $vars['api_token'],'masked api_token');
+        $this->assertEquals($vars['foo'], 'bar', 'did not alter foo');
+        $this->assertEquals($vars['password'], 'hello', 'did not alter password');
+        $this->assertEquals($vars['the_secret'], 'hello', 'did not alter the_secret');
+        $this->assertEquals($vars['a_password_here'], 'hello', 'did not alter a_password_here');
+        $this->assertEquals($vars['mypasswd'], 'hello', 'did not alter mypasswd');
+        $this->assertEquals($vars['authorization'], 'Basic dXNlcm5hbWU6cGFzc3dvcmQ=', 'did not alter authorization');
+        $this->assertEquals(Raven_SanitizeDataProcessor::MASK, $vars['api_token'], 'masked api_token');
 
         $this->assertEquals(Raven_SanitizeDataProcessor::MASK, $vars['card_number']['0'], 'masked card_number[0]');
-        $this->assertEquals($vars['card_number']['1'], $vars['card_number']['1'],'did not alter card_number[1]');
+        $this->assertEquals($vars['card_number']['1'], $vars['card_number']['1'], 'did not alter card_number[1]');
     }
 
     /**
@@ -154,7 +157,8 @@ class Raven_Tests_SanitizeDataProcessorTest extends PHPUnit_Framework_TestCase
      *
      * @return array
      */
-    public static function overrideDataProvider(){
+    public static function overrideDataProvider()
+    {
         $processorOptions = array(
             'Raven_SanitizeDataProcessor' => array(
                 'fields_re' => '/(api_token)/i',

--- a/test/Raven/Tests/SerializerTest.php
+++ b/test/Raven/Tests/SerializerTest.php
@@ -45,5 +45,4 @@ class Raven_Tests_SerializerTest extends PHPUnit_Framework_TestCase
         $result = Raven_Serializer::serialize($input, 3);
         $this->assertEquals(array(array(array('Array of length 1'))), $result);
     }
-
 }

--- a/test/Raven/Tests/StacktraceTest.php
+++ b/test/Raven/Tests/StacktraceTest.php
@@ -69,8 +69,6 @@ class Raven_Tests_StacktraceTest extends PHPUnit_Framework_TestCase
         $this->assertEquals(11, $frame["lineno"]);
         $this->assertEquals('include_once', $frame["function"]);
         $this->assertEquals('a_test($foo);', $frame["context_line"]);
-
-
     }
 
     public function testSimpleUnshiftedTrace()
@@ -108,8 +106,6 @@ class Raven_Tests_StacktraceTest extends PHPUnit_Framework_TestCase
         $this->assertEquals('include_once', $frame["function"]);
         $this->assertEquals('friend', $frame['vars']['param1']);
         $this->assertEquals('a_test($foo);', $frame["context_line"]);
-
-
     }
 
     public function testShiftedCaptureVars()
@@ -152,8 +148,6 @@ class Raven_Tests_StacktraceTest extends PHPUnit_Framework_TestCase
         $this->assertEquals('include_once', $frame["function"]);
         $this->assertEquals('a_test($foo);', $frame["context_line"]);
         $this->assertEquals($vars, $frame['vars']);
-
-
     }
 
     public function testUnshiftedCaptureVars()
@@ -196,8 +190,6 @@ class Raven_Tests_StacktraceTest extends PHPUnit_Framework_TestCase
         $this->assertEquals('include_once', $frame["function"]);
         $this->assertEquals($vars, $frame['vars']);
         $this->assertEquals('a_test($foo);', $frame["context_line"]);
-
-
     }
 
     public function testDoesFixFrameInfo()


### PR DESCRIPTION
This PR

* [x] requires [`fabpot/php-cs-fixer`](https://github.com/FriendsOfPHP/PHP-CS-Fixer) as a development dependency
* [x] adds a simple configuration for `php-cs-fixer´, enabling all [PSR-2](https://github.com/php-fig/fig-standards/blob/master/accepted/PSR-2-coding-style-guide.md) fixers 
* [x] adds `cs` and `cs-dry-run` targets to `Makefile`
* [x] performs a dry-run of `php-cs-fixer` on Travis
* [ ] runs `make cs` to fix CS issues

## Usage

Install dependencies:

```
$ composer install
```

Detect CS issues:

```
$ make cs-dry-run
```

Fix CS issues:

```
$ make cs
```