### PR TITLE
Enhancement: Cache dependencies installed with Composer on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,8 +8,8 @@ php:
   - hhvm
 
 matrix:
-    allow_failures:
-        - php: hhvm
+  allow_failures:
+    - php: hhvm
 
 sudo: false
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,11 +7,11 @@ php:
   - 5.6
   - hhvm
 
-sudo: false
-
 matrix:
     allow_failures:
         - php: hhvm
+
+sudo: false
 
 cache:
   directories:

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,10 @@ matrix:
     allow_failures:
         - php: hhvm
 
+cache:
+  directories:
+    - $HOME/.composer/cache
+
 install:
   - if [[ $TRAVIS_PHP_VERSION != "5.2" ]]; then composer install; fi
 


### PR DESCRIPTION
This PR

* [x] enables caching of dependencies installed with Composer on Travis
* [x] applies a bit of boy-scouting to `.travis.yml`

Follows #203.