### PR TITLE
Require the curl extension in composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,8 @@
         "phpunit/phpunit": "^4.6.6"
     },
     "require": {
-        "php": ">=5.2.4"
+        "php": ">=5.2.4",
+        "ext-curl": "*"
     },
     "bin": [
         "bin/raven"


### PR DESCRIPTION
Require the curl extension in composer.json