### PR TITLE
Error Types processed by ErrorHandler can be expaned

### DIFF
--- a/lib/Raven/ErrorHandler.php
+++ b/lib/Raven/ErrorHandler.php
@@ -31,6 +31,32 @@ class Raven_ErrorHandler
     private $send_errors_last = false;
     private $error_types = -1;
 
+    /**
+     * @var array
+     * Error types that can be processed by the handler
+     */
+    private $validErrorTypes = array(
+        E_ERROR,
+        E_WARNING,
+        E_PARSE,
+        E_NOTICE,
+        E_CORE_ERROR,
+        E_CORE_WARNING,
+        E_COMPILE_ERROR,
+        E_COMPILE_WARNING,
+        E_USER_ERROR,
+        E_USER_WARNING,
+        E_USER_NOTICE,
+        E_STRICT,
+        E_RECOVERABLE_ERROR,
+        E_DEPRECATED,
+        E_USER_DEPRECATED,
+    );
+
+    /**
+     * @var array
+     * Error types that are always processed by the handler
+     */
     private $defaultErrorTypes = array(
         E_ERROR,
         E_PARSE,
@@ -79,6 +105,7 @@ class Raven_ErrorHandler
 
     /**
      * Nothing by default, use it in child classes for catching other types of errors
+     * Only constants from $this->validErrorTypes can be used
      *
      * @return array
      */
@@ -90,9 +117,11 @@ class Raven_ErrorHandler
     /**
      * @return array
      */
-    protected function getErrorTypesToProcess()
+    private function getErrorTypesToProcess()
     {
-        return $this->defaultErrorTypes + $this->getAdditionalErrorTypesToProcess();
+        $additionalErrorTypes = array_intersect($this->getAdditionalErrorTypesToProcess(), $this->validErrorTypes);
+        // array_unique so bitwise "or" operation wouldn't fail if some error type gets repeated
+        return array_unique($this->defaultErrorTypes + $additionalErrorTypes);
     }
 
     public function handleFatalError()


### PR DESCRIPTION
I'm using Sentry for one of the projects at work and I needed to process deprecated errors after upgrading to higher version of PHP. To implement that, I had to extend the ErrorHandler and copy-paste some of its logic to proccess additional two types of errors. That is messy and I think this way would be a lot better.