### PR TITLE
CURLOPT_CONNECTTIMEOUT_MS not defined in some PHP versions

### DIFF
--- a/lib/Raven/Client.php
+++ b/lib/Raven/Client.php
@@ -622,6 +622,13 @@ class Raven_Client
         if (defined('CURLOPT_TIMEOUT_MS')) {
             // MS is available in curl >= 7.16.2
             $timeout = max(1, ceil(1000 * $this->timeout));
+
+            // some versions of PHP 5.3 don't have this defined correctly
+            if (!defined('CURLOPT_CONNECTTIMEOUT_MS')) {
+                //see http://stackoverflow.com/questions/9062798/php-curl-timeout-is-not-working/9063006#9063006
+                define('CURLOPT_CONNECTTIMEOUT_MS', 156);
+            }
+
             $options[CURLOPT_CONNECTTIMEOUT_MS] = $timeout;
             $options[CURLOPT_TIMEOUT_MS] = $timeout;
         } else {


### PR DESCRIPTION
Some versions of PHP do not correctly defined this constant.

 * http://stackoverflow.com/questions/9062798/php-curl-timeout-is-not-working/9063006#9063006
 * http://php.net/manual/en/function.curl-setopt.php#107314

This addresses by defining correctly if not already set.

![image](https://cloud.githubusercontent.com/assets/810546/7682123/ae68f9cc-fd43-11e4-8f23-87c2c633324f.png)
