### PR TITLE
$errcontext must not be modified.

### DIFF
--- a/lib/Raven/Stacktrace.php
+++ b/lib/Raven/Stacktrace.php
@@ -89,7 +89,7 @@ class Raven_Stacktrace
             // dont set this as an empty array as PHP will treat it as a numeric array
             // instead of a mapping which goes against the defined Sentry spec
             if (!empty($vars)) {
-                $cleanVars = [];
+                $cleanVars = array();
                 foreach ($vars as $key => $value) {
                     if (is_string($value) || is_numeric($value)) {
                         $cleanVars[$key] = substr($value, 0, $frame_var_limit);

--- a/lib/Raven/Stacktrace.php
+++ b/lib/Raven/Stacktrace.php
@@ -89,12 +89,15 @@ class Raven_Stacktrace
             // dont set this as an empty array as PHP will treat it as a numeric array
             // instead of a mapping which goes against the defined Sentry spec
             if (!empty($vars)) {
+                $cleanVars = [];
                 foreach ($vars as $key => $value) {
                     if (is_string($value) || is_numeric($value)) {
-                        $vars[$key] = substr($value, 0, $frame_var_limit);
+                        $cleanVars[$key] = substr($value, 0, $frame_var_limit);
+                    } else {
+                        $cleanVars[$key] = $value;
                     }
                 }
-                $frame['vars'] = $vars;
+                $frame['vars'] = $cleanVars;
             }
 
             $result[] = $frame;


### PR DESCRIPTION
The contents of the errcontext param of the PHP error handler must not
be modified since it may contain references. If control is returned to
the code which triggered the error (so a non-fatal error) we might
have changed important state.
This would be bad.

Raven_Stacktrace::get_stack_info can be passed this errcontext, and will
truncate strings in the array to a given limit, modifying errcontext in
the process. Whoops.