### PR TITLE
support non-utf8 language

### DIFF
--- a/lib/Raven/Serializer.php
+++ b/lib/Raven/Serializer.php
@@ -68,7 +68,7 @@ class Raven_Serializer
             $value = (string) $value;
 
             if (function_exists('mb_convert_encoding')) {
-                $value = mb_convert_encoding($value, 'UTF-8', 'UTF-8');
+                $value = mb_convert_encoding($value, 'UTF-8', 'auto');
             }
 
             return $value;


### PR DESCRIPTION
In our project, we use gbk for default encoding. So, why not just change sentry to support non-utf8 language, like gbk.

By the way, i don't understand why using "$value = mb_convert_encoding($value, 'UTF-8', 'UTF-8');"?