### PR TITLE
Use /usr/bin/env in test script

### DIFF
--- a/bin/raven
+++ b/bin/raven
@@ -1,4 +1,4 @@
-#!/usr/bin/php
+#!/usr/bin/env php
 <?php
 
 // Maximize error reporting


### PR DESCRIPTION
Use `/usr/bin/env php` in the shebang of the test script to make it more compatible with e.g. freebsd, where php would be found in /usr/local/bin.