### PR TITLE
ErrorHandler fix for getErrorTypesToProcess()

### DIFF
--- a/lib/Raven/ErrorHandler.php
+++ b/lib/Raven/ErrorHandler.php
@@ -124,7 +124,7 @@ class Raven_ErrorHandler
     {
         $additionalErrorTypes = array_intersect($this->getAdditionalErrorTypesToProcess(), $this->validErrorTypes);
         // array_unique so bitwise "or" operation wouldn't fail if some error type gets repeated
-        return array_unique($this->defaultErrorTypes + $additionalErrorTypes);
+        return array_unique(array_merge($this->defaultErrorTypes, $additionalErrorTypes));
     }
 
     public function handleFatalError()


### PR DESCRIPTION
In `getErrorTypesToProcess()` "+" was used to combine two arrays, and that doesn't work if `$additionalErrorTypes` is defined without setting the keys since array union ignores values from the second array whose keys exist in the first array. `array_merge` does what is expected.