### PR TITLE
Updated Symfony2 example to use correct dependency injection

### DIFF
--- a/docs/integrations/symfony2.rst
+++ b/docs/integrations/symfony2.rst
@@ -39,21 +39,21 @@ Capturing context can be done via a monolog processor:
 
     namespace AppBundle\Monolog;
 
-    use Symfony\Component\Security\Core\SecurityContext;
     use AppBundlee\Entity\User;
+    use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorage;
 
     class SentryContextProcessor
     {
-        protected $securityContext;
+        protected $tokenStorage;
 
-        public function __construct(SecurityContext $securityContext)
+        public function __construct(TokenStorage $tokenStorage)
         {
-            $this->securityContext = $securityContext;
+            $this->tokenStorage = $tokenStorage;
         }
 
         public function processRecord($record)
         {
-            $user = $this->securityContext->getToken()->getUser();
+            $user = $this->tokenStorage->getToken()->getUser();
 
             if ($user instanceof User) {
                 $record['context']['user'] = array(
@@ -80,6 +80,6 @@ You'll then register the processor in your config:
     services:
         monolog.processor.sentry_context:
             class: AppBundle\Monolog\SentryContextProcessor
-            arguments:  ["@security.context"]
+            arguments:  ["@security.token_storage"]
             tags:
                 - { name: monolog.processor, method: processRecord, handler: sentry }

--- a/docs/integrations/symfony2.rst
+++ b/docs/integrations/symfony2.rst
@@ -39,26 +39,23 @@ Capturing context can be done via a monolog processor:
 
     namespace Acme\Bundle\AcmeBundle\Monolog;
 
-    use Symfony\Component\DependencyInjection\ContainerInterface;
+    use Symfony\Component\Security\Core\SecurityContext;
     use Acme\Bundle\AcmeBundle\Entity\User;
 
-    class SentryContextProcessor {
+    class SentryContextProcessor
+    {
+        protected $securityContext;
 
-        protected $container;
-
-        public function __construct(ContainerInterface $container)
+        public function __construct(SecurityContext $securityContext)
         {
-            $this->container = $container;
+            $this->securityContext = $securityContext;
         }
 
         public function processRecord($record)
         {
-            $securityContext = $this->container->get('security.context');
-            $user = $securityContext->getToken()->getUser();
+            $user = $this->securityContext->getToken()->getUser();
 
-            if($user instanceof User)
-            {
-
+            if ($user instanceof User) {
                 $record['context']['user'] = array(
                     'name' => $user->getName(),
                     'username' => $user->getUsername(),
@@ -74,7 +71,6 @@ Capturing context can be done via a monolog processor:
 
             return $record;
         }
-
     }
 
 You'll then register the processor in your config:
@@ -84,6 +80,6 @@ You'll then register the processor in your config:
     services:
         monolog.processor.sentry_context:
             class: Applestump\Bundle\ShowsBundle\Monolog\SentryContextProcessor
-            arguments:  ["@service_container"]
+            arguments:  ["@security.context"]
             tags:
                 - { name: monolog.processor, method: processRecord, handler: sentry }

--- a/docs/integrations/symfony2.rst
+++ b/docs/integrations/symfony2.rst
@@ -83,3 +83,6 @@ You'll then register the processor in your config:
             arguments:  ["@security.token_storage"]
             tags:
                 - { name: monolog.processor, method: processRecord, handler: sentry }
+
+
+If you're using Symfony < 2.6 then you need to use ``security.context`` instead of ``security.token_storage``.

--- a/docs/integrations/symfony2.rst
+++ b/docs/integrations/symfony2.rst
@@ -79,7 +79,7 @@ You'll then register the processor in your config:
 
     services:
         monolog.processor.sentry_context:
-            class: Applestump\Bundle\ShowsBundle\Monolog\SentryContextProcessor
+            class: Acme\Bundle\AcmeBundle\Monolog\SentryContextProcessor
             arguments:  ["@security.context"]
             tags:
                 - { name: monolog.processor, method: processRecord, handler: sentry }

--- a/docs/integrations/symfony2.rst
+++ b/docs/integrations/symfony2.rst
@@ -37,10 +37,10 @@ Capturing context can be done via a monolog processor:
 
 .. sourcecode:: php
 
-    namespace Acme\Bundle\AcmeBundle\Monolog;
+    namespace AppBundle\Monolog;
 
     use Symfony\Component\Security\Core\SecurityContext;
-    use Acme\Bundle\AcmeBundle\Entity\User;
+    use AppBundlee\Entity\User;
 
     class SentryContextProcessor
     {
@@ -79,7 +79,7 @@ You'll then register the processor in your config:
 
     services:
         monolog.processor.sentry_context:
-            class: Acme\Bundle\AcmeBundle\Monolog\SentryContextProcessor
+            class: AppBundle\Monolog\SentryContextProcessor
             arguments:  ["@security.context"]
             tags:
                 - { name: monolog.processor, method: processRecord, handler: sentry }

--- a/docs/integrations/symfony2.rst
+++ b/docs/integrations/symfony2.rst
@@ -39,14 +39,14 @@ Capturing context can be done via a monolog processor:
 
     namespace AppBundle\Monolog;
 
-    use AppBundlee\Entity\User;
-    use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorage;
+    use AppBundle\Entity\User;
+    use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
 
     class SentryContextProcessor
     {
         protected $tokenStorage;
 
-        public function __construct(TokenStorage $tokenStorage)
+        public function __construct(TokenStorageInterface $tokenStorage)
         {
             $this->tokenStorage = $tokenStorage;
         }


### PR DESCRIPTION
One should not inject the service container to later retrieve services, but let the container injection the needed services directly.

Also please be aware that `security.context` is deprecated since Symfony 2.6, but I'm not sure if the example should still support older versions.