### PR TITLE
Fix deprecations in example symfony2 integration

### DIFF
--- a/docs/integrations/symfony2.rst
+++ b/docs/integrations/symfony2.rst
@@ -37,10 +37,10 @@ Capturing context can be done via a monolog processor:
 
 .. sourcecode:: php
 
-    namespace Acme\Bundle\AcmeBundle\Monolog;
+    namespace AppBundle\Monolog;
 
     use Symfony\Component\DependencyInjection\ContainerInterface;
-    use Acme\Bundle\AcmeBundle\Entity\User;
+    use AppBundle\Entity\User;
 
     class SentryContextProcessor {
 
@@ -53,11 +53,11 @@ Capturing context can be done via a monolog processor:
 
         public function processRecord($record)
         {
-            $securityContext = $this->container->get('security.context');
-            $user = $securityContext->getToken()->getUser();
+            // If you're using Symfony < 2.6 then use 'security.context' instead
+            $tokenStorage = $this->container->get('security.token_storage');
+            $user = $tokenStorage->getToken()->getUser();
 
-            if($user instanceof User)
-            {
+            if($user instanceof User) {
 
                 $record['context']['user'] = array(
                     'name' => $user->getName(),
@@ -83,7 +83,7 @@ You'll then register the processor in your config:
 
     services:
         monolog.processor.sentry_context:
-            class: Applestump\Bundle\ShowsBundle\Monolog\SentryContextProcessor
+            class: AppBundle\Monolog\SentryContextProcessor
             arguments:  ["@service_container"]
             tags:
                 - { name: monolog.processor, method: processRecord, handler: sentry }


### PR DESCRIPTION
* Use the suggested default AppBundle and made it consistent (previously the class and the service definition had different namespaces).
* Use `security.token_storage` instead of `security.context` to retrieve user (new in Symfony 2.6, and generating deprecation notices since 2.7 - I left the old service name in a comment since 2.3 LTS is still valid).
* Tiny tiny pedantic PSR-2 tweak to move if-statement opening brace :innocent: