### PR TITLE
Clarify license in Composer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
     "description": "A PHP client for Sentry (http://getsentry.com)",
     "keywords": ["log", "logging"],
     "homepage": "http://getsentry.com",
-    "license": "BSD",
+    "license": "BSD-3-Clause",
     "authors": [
         {
             "name": "David Cramer",


### PR DESCRIPTION
[Composer ](https://getcomposer.org/doc/04-schema.md#license) uses identifiers from the [SPDX license list](https://spdx.org/licenses/).
Services like https://www.versioneye.com/ uses it to infer GPL compatibility.
The "BSD" license does not exist in this referential leading to false positives.
I updated it to "BSD-3-Clause" which seem to be what the project uses.