### PR TITLE
if not isset email, don't set to user_context

### DIFF
--- a/lib/Raven/Client.php
+++ b/lib/Raven/Client.php
@@ -869,10 +869,11 @@ class Raven_Client
      */
     public function set_user_data($id, $email=null, $data=array())
     {
-        $this->user_context(array_merge(array(
-            'id'    => $id,
-            'email' => $email,
-        ), $data));
+        $user = array('id' => $id);
+        if (isset($email)) {
+            $user['email'] = $email;
+        }
+        $this->user_context(array_merge($user, $data));
     }
 
     /**


### PR DESCRIPTION
if call function

```php
$client->set_user_data(1);
```

sentry 
```
There was 1 error encountered while processing this event
Discarded invalid value for parameter 'sentry.interfaces.User' Collapse
{
  "name": "sentry.interfaces.User",
  "value": {
    "id": 1,
    "email": "null"
  }
}
```