### PR TITLE
Support x forwarded proto

### DIFF
--- a/lib/Raven/Client.php
+++ b/lib/Raven/Client.php
@@ -74,6 +74,7 @@ class Raven_Client
         $this->ca_cert = Raven_util::get($options, 'ca_cert', $this->get_default_ca_cert());
         $this->verify_ssl = Raven_util::get($options, 'verify_ssl', true);
         $this->curl_ssl_version = Raven_Util::get($options, 'curl_ssl_version');
+        $this->trust_x_forwarded_proto = Raven_Util::get($options, 'trust_x_forwarded_proto');
 
         $this->processors = $this->setProcessorsFromOptions($options);
 
@@ -812,7 +813,9 @@ class Raven_Client
             return true;
         }
 
-        if (!empty($_SERVER['X-FORWARDED-PROTO']) && $_SERVER['X-FORWARDED-PROTO'] === 'https') {
+        if (!empty($this->trust_x_forwarded_proto) &&
+            !empty($_SERVER['X-FORWARDED-PROTO']) &&
+            $_SERVER['X-FORWARDED-PROTO'] === 'https') {
             return true;
         }
 

--- a/lib/Raven/Client.php
+++ b/lib/Raven/Client.php
@@ -781,7 +781,7 @@ class Raven_Client
      *
      * @return string|null
      */
-    private function get_current_url()
+    protected function get_current_url()
     {
         // When running from commandline the REQUEST_URI is missing.
         if (!isset($_SERVER['REQUEST_URI'])) {
@@ -802,13 +802,13 @@ class Raven_Client
      *
      * @return bool
      */
-    private function isHttps()
+    protected function isHttps()
     {
         if (!empty($_SERVER['HTTPS']) && $_SERVER['HTTPS'] !== 'off') {
             return true;
         }
 
-        if ($_SERVER['SERVER_PORT'] == 443) {
+        if (!empty($_SERVER['SERVER_PORT']) && $_SERVER['SERVER_PORT'] == 443) {
             return true;
         }
 

--- a/lib/Raven/Client.php
+++ b/lib/Raven/Client.php
@@ -788,15 +788,35 @@ class Raven_Client
             return null;
         }
 
-        $schema = (!empty($_SERVER['HTTPS']) && $_SERVER['HTTPS'] !== 'off'
-            || $_SERVER['SERVER_PORT'] == 443) ? "https://" : "http://";
-
         // HTTP_HOST is a client-supplied header that is optional in HTTP 1.0
         $host = (!empty($_SERVER['HTTP_HOST']) ? $_SERVER['HTTP_HOST']
             : (!empty($_SERVER['LOCAL_ADDR'])  ? $_SERVER['LOCAL_ADDR']
             : (!empty($_SERVER['SERVER_ADDR']) ? $_SERVER['SERVER_ADDR'] : '')));
 
-        return $schema . $host . $_SERVER['REQUEST_URI'];
+        $httpS = $this->isHttps() ? 's' : '';
+        return "http{$httpS}://{$host}{$_SERVER['REQUEST_URI']}";
+    }
+
+    /**
+     * Was the current request made over https?
+     *
+     * @return bool
+     */
+    private function isHttps()
+    {
+        if (!empty($_SERVER['HTTPS']) && $_SERVER['HTTPS'] !== 'off') {
+            return true;
+        }
+
+        if ($_SERVER['SERVER_PORT'] == 443) {
+            return true;
+        }
+
+        if (!empty($_SERVER['X-FORWARDED-PROTO']) && $_SERVER['X-FORWARDED-PROTO'] === 'https') {
+            return true;
+        }
+
+        return false;
     }
 
     /**

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<phpunit backupGlobals="false"
-         backupStaticAttributes="false"
+<phpunit backupStaticAttributes="false"
          colors="true"
          convertErrorsToExceptions="true"
          convertNoticesToExceptions="true"

--- a/test/Raven/Tests/ClientTest.php
+++ b/test/Raven/Tests/ClientTest.php
@@ -671,47 +671,47 @@ class Raven_Tests_ClientTest extends PHPUnit_Framework_TestCase
      */
     public function currentUrlProvider()
     {
-        return [
-            [
-                [],
+        return array(
+            array(
+                array(),
                 null,
                 'If request uri is not set, expect nothing'
-            ],
-            [
-                [
+            ),
+            array(
+                array(
                     'REQUEST_URI' => '/',
                     'HTTP_HOST' => 'example.com',
-                ],
+                ),
                 'http://example.com/',
                 'Simple http case'
-            ],
-            [
-                [
+            ),
+            array(
+                array(
                     'REQUEST_URI' => '/',
                     'HTTP_HOST' => 'example.com',
                     'HTTPS' => 'on'
-                ],
+                ),
                 'https://example.com/',
                 'Simple https case'
-            ],
-            [
-                [
+            ),
+            array(
+                array(
                     'REQUEST_URI' => '/',
                     'HTTP_HOST' => 'example.com',
                     'SERVER_PORT' => '443'
-                ],
+                ),
                 'https://example.com/',
                 'Https based on the server port'
-            ],
-            [
-                [
+            ),
+            array(
+                array(
                     'REQUEST_URI' => '/',
                     'HTTP_HOST' => 'example.com',
                     'X-FORWARDED-PROTO' => 'https'
-                ],
+                ),
                 'https://example.com/',
                 'Https based on the forwarded protocol'
-            ]
-        ];
+            )
+        );
     }
 }


### PR DESCRIPTION
If the backend server is behind a load balancer, reported urls are always http - as that's the protocol the loadbalancer is talking to the backend server with. The reported url should match that of the client.