### PR TITLE
Ensure error_types are handled correctly

### DIFF
--- a/lib/Raven/ErrorHandler.php
+++ b/lib/Raven/ErrorHandler.php
@@ -29,11 +29,12 @@ class Raven_ErrorHandler
     private $call_existing_error_handler = false;
     private $reservedMemory;
     private $send_errors_last = false;
-    private $error_types = -1;
+    private $error_types;
 
     /**
      * @var array
-     * Error types that can be processed by the handler
+     * Error types that can be processed by the handler. Only used
+     * by the shutdown fatal handler.
      */
     private $validErrorTypes = array(
         E_ERROR,
@@ -55,7 +56,8 @@ class Raven_ErrorHandler
 
     /**
      * @var array
-     * The default Error types that are always processed by the handler. Can be set during construction.
+     * The default Error types that are always processed.  Only used
+     * by the shutdown fatal handler. Can be set during construction.
      */
     private $defaultErrorTypes = array(
         E_ERROR,
@@ -92,7 +94,7 @@ class Raven_ErrorHandler
 
     public function handleError($code, $message, $file = '', $line = 0, $context=array())
     {
-        if ($this->error_types & $code & error_reporting()) {
+        if ($this->error_types & $code) {
             $e = new ErrorException($message, 0, $code, $file, $line);
             $this->handleException($e, true, $context);
         }
@@ -155,10 +157,13 @@ class Raven_ErrorHandler
         $this->call_existing_exception_handler = $call_existing_exception_handler;
     }
 
-    public function registerErrorHandler($call_existing_error_handler = true, $error_types = -1)
+    public function registerErrorHandler($call_existing_error_handler = true, $error_types = null)
     {
+        if ($error_types === null) {
+            $error_type = error_reporting();
+        }
         $this->error_types = $error_types;
-        $this->old_error_handler = set_error_handler(array($this, 'handleError'), error_reporting());
+        $this->old_error_handler = set_error_handler(array($this, 'handleError'), $error_types);
         $this->call_existing_error_handler = $call_existing_error_handler;
     }
 

--- a/lib/Raven/ErrorHandler.php
+++ b/lib/Raven/ErrorHandler.php
@@ -81,6 +81,7 @@ class Raven_ErrorHandler
             $this->client->store_errors_for_bulk_send = true;
             register_shutdown_function(array($this->client, 'sendUnsentErrors'));
         }
+        $this->error_types = error_reporting();
     }
 
     public function handleException($e, $isError = false, $vars = null)
@@ -99,7 +100,7 @@ class Raven_ErrorHandler
             $this->handleException($e, true, $context);
         }
 
-        if ($this->call_existing_error_handler) {
+        if (error_reporting() & $code && $this->call_existing_error_handler) {
             if ($this->old_error_handler) {
                 return call_user_func($this->old_error_handler, $code, $message, $file, $line, $context);
             } else {
@@ -159,11 +160,11 @@ class Raven_ErrorHandler
 
     public function registerErrorHandler($call_existing_error_handler = true, $error_types = null)
     {
-        if ($error_types === null) {
+        if ($error_types == null) {
             $error_type = error_reporting();
         }
         $this->error_types = $error_types;
-        $this->old_error_handler = set_error_handler(array($this, 'handleError'), $error_types);
+        $this->old_error_handler = set_error_handler(array($this, 'handleError'), -1);
         $this->call_existing_error_handler = $call_existing_error_handler;
     }
 


### PR DESCRIPTION
This corrects behavior that would allow you to specify which error_types are handled by the SDK, but would simply ignore it if they were also not included in error_reporting. 