### PR TITLE
Ensure error_types are handled correctly

### DIFF
--- a/test/Raven/Tests/ErrorHandlerTest.php
+++ b/test/Raven/Tests/ErrorHandlerTest.php
@@ -16,21 +16,30 @@ class Raven_Tests_ErrorHandlerTest extends PHPUnit_Framework_TestCase
     public function setUp()
     {
         $this->errorLevel = error_reporting();
+        $this->errorHandlerCalled = false;
+        $this->existingErrorHandler = set_error_handler(array($this, 'errorHandler'), -1);
+    }
+
+    public function errorHandler()
+    {
+        $this->errorHandlerCalled = true;
     }
 
     public function tearDown()
     {
+        // XXX(dcramer): this isn't great as it doesnt restore the old error reporting level
+        set_error_handler(array($this, 'errorHandler'), error_reporting());
         error_reporting($this->errorLevel);
     }
 
     public function testErrorsAreLoggedAsExceptions()
     {
-        $client = $this->getMock('Client', array('captureException', 'getIdent'));
+        $client = $this->getMock('Client', array('captureException', 'getIdent', 'sendUnsentErrors'));
         $client->expects($this->once())
                ->method('captureException')
                ->with($this->isInstanceOf('ErrorException'));
 
-        $handler = new Raven_ErrorHandler($client);
+        $handler = new Raven_ErrorHandler($client, E_ALL);
         $handler->handleError(E_WARNING, 'message');
     }
 
@@ -47,31 +56,6 @@ class Raven_Tests_ErrorHandlerTest extends PHPUnit_Framework_TestCase
         $handler->handleException($e);
     }
 
-    public function testErrorHandlerCheckSilentReporting()
-    {
-        $client = $this->getMock('Client', array('captureException', 'getIdent'));
-        $client->expects($this->never())
-               ->method('captureException');
-
-        $handler = new Raven_ErrorHandler($client);
-        $handler->registerErrorHandler(false);
-
-        @trigger_error('Silent', E_USER_WARNING);
-    }
-
-    public function testErrorHandlerBlockErrorReporting()
-    {
-        $client = $this->getMock('Client', array('captureException', 'getIdent'));
-        $client->expects($this->never())
-               ->method('captureException');
-
-        $handler = new Raven_ErrorHandler($client);
-        $handler->registerErrorHandler(false);
-
-        error_reporting(E_USER_ERROR);
-        trigger_error('Warning', E_USER_WARNING);
-    }
-
     public function testErrorHandlerPassErrorReportingPass()
     {
         $client = $this->getMock('Client', array('captureException', 'getIdent'));
@@ -79,9 +63,54 @@ class Raven_Tests_ErrorHandlerTest extends PHPUnit_Framework_TestCase
                ->method('captureException');
 
         $handler = new Raven_ErrorHandler($client);
-        $handler->registerErrorHandler(false);
+        $handler->registerErrorHandler(false, -1);
 
         error_reporting(E_USER_WARNING);
+        trigger_error('Warning', E_USER_WARNING);
+    }
+
+    public function testErrorHandlerPropagatesUsingErrorReporting()
+    {
+        $client = $this->getMock('Client', array('captureException', 'getIdent'));
+        $client->expects($this->never())
+               ->method('captureException');
+
+        $handler = new Raven_ErrorHandler($client);
+        $handler->registerErrorHandler(true, E_NONE);
+
+        error_reporting(E_USER_WARNING);
+        trigger_error('Warning', E_USER_WARNING);
+
+        $this->assertEquals($this->errorHandlerCalled, 1);
+    }
+
+    // Because we cannot **know** that a user silenced an error, we always
+    // defer to respecting the error reporting settings.
+    public function testSilentErrorsAreReported()
+    {
+        $client = $this->getMock('Client', array('captureException', 'getIdent'));
+        $client->expects($this->never())
+               ->method('captureException');
+
+        error_reporting(E_USER_WARNING);
+
+        $handler = new Raven_ErrorHandler($client);
+        $handler->registerErrorHandler(false);
+
+        @trigger_error('Silent', E_USER_WARNING);
+    }
+
+    public function testErrorHandlerDefaultsErrorReporting()
+    {
+        $client = $this->getMock('Client', array('captureException', 'getIdent'));
+        $client->expects($this->never())
+               ->method('captureException');
+
+        error_reporting(E_USER_ERROR);
+
+        $handler = new Raven_ErrorHandler($client);
+        $handler->registerErrorHandler(false);
+
         trigger_error('Warning', E_USER_WARNING);
     }
 }


### PR DESCRIPTION
This corrects behavior that would allow you to specify which error_types are handled by the SDK, but would simply ignore it if they were also not included in error_reporting.

Additionally we introduce a backwards incompatible change: silenced errors are no longer ignored. There's no way to detect when you intended an error to be silent without losing behavior introduced here (correctness on specifying error_types).