### PR TITLE
Further improve error_reporting usage

### DIFF
--- a/test/Raven/Tests/ErrorHandlerTest.php
+++ b/test/Raven/Tests/ErrorHandlerTest.php
@@ -69,16 +69,33 @@ class Raven_Tests_ErrorHandlerTest extends PHPUnit_Framework_TestCase
         trigger_error('Warning', E_USER_WARNING);
     }
 
-    public function testErrorHandlerPropagatesUsingErrorReporting()
+    public function testErrorHandlerPropagates()
     {
         $client = $this->getMock('Client', array('captureException', 'getIdent'));
         $client->expects($this->never())
                ->method('captureException');
 
         $handler = new Raven_ErrorHandler($client);
-        $handler->registerErrorHandler(true, E_NONE);
+        $handler->registerErrorHandler(true, E_DEPRECATED);
 
         error_reporting(E_USER_WARNING);
+        trigger_error('Warning', E_USER_WARNING);
+
+        $this->assertEquals($this->errorHandlerCalled, 1);
+    }
+
+    public function testErrorHandlerRespectsErrorReportingDefault()
+    {
+        $client = $this->getMock('Client', array('captureException', 'getIdent'));
+        $client->expects($this->once())
+               ->method('captureException');
+
+        error_reporting(E_DEPRECATED);
+
+        $handler = new Raven_ErrorHandler($client);
+        $handler->registerErrorHandler(true);
+
+        error_reporting(E_ALL);
         trigger_error('Warning', E_USER_WARNING);
 
         $this->assertEquals($this->errorHandlerCalled, 1);


### PR DESCRIPTION
- When no error types are defined, default to error_reporting (at time of error)
- Deprecates the default error type methods as they are no implemented entirely.
- Allow specifying error types on instantiation of ErrorHandler

Refs GH-260