### PR TITLE
Fix curl_exec method to work with self-signed certificates

### DIFF
--- a/lib/Raven/Client.php
+++ b/lib/Raven/Client.php
@@ -662,6 +662,8 @@ class Raven_Client
         $cmd .= '-d \''. $data .'\' ';
         $cmd .= '\''. $url .'\' ';
         $cmd .= '-m 5 ';  // 5 second timeout for the whole process (connect + send)
+        if (!$this->verify_ssl) 
+            $cmd .= '-k ';
         $cmd .= '> /dev/null 2>&1 &'; // ensure exec returns immediately while curl runs in the background
 
         exec($cmd);


### PR DESCRIPTION
Bug fixed: send_http_asynchronous_curl_exec method ignores verify_ssl flag and doesn't work with self-signed certificates.

Curl flag added.