### PR TITLE
Improve serialization (fixes GH-269)

### DIFF
--- a/lib/Raven/Client.php
+++ b/lib/Raven/Client.php
@@ -454,10 +454,18 @@ class Raven_Client
         // avoid empty arrays (which dont convert to dicts)
         if (empty($data['extra'])) {
             unset($data['extra']);
+        } else {
+            $data['extra'] = Raven_Serializer::serialize($data['extra']);
         }
         if (empty($data['tags'])) {
             unset($data['tags']);
+        } else {
+            $data['tags'] = Raven_Serializer::serialize($data['tags']);
         }
+        if (!empty($data['user'])) {
+            $data['user'] = Raven_Serializer::serialize($data['user']);
+        }
+
 
         if ((!$stack && $this->auto_log_stacks) || $stack === true) {
             $stack = debug_backtrace();
@@ -502,8 +510,6 @@ class Raven_Client
         if (!class_exists('Raven_Serializer')) {
             spl_autoload_call('Raven_Serializer');
         }
-
-        $data = Raven_Serializer::serialize($data);
     }
 
     /**

--- a/lib/Raven/Serializer.php
+++ b/lib/Raven/Serializer.php
@@ -30,7 +30,7 @@ class Raven_Serializer
      * Serialize an object (recursively) into something safe for data
      * sanitization and encoding.
      */
-    public static function serialize($value, $max_depth=9, $_depth=0)
+    public static function serialize($value, $max_depth=3, $_depth=0)
     {
         if (is_object($value) || is_resource($value)) {
             return self::serializeValue($value);
@@ -48,6 +48,35 @@ class Raven_Serializer
 
     public static function serializeValue($value)
     {
+        if (is_null($value) || is_bool($value) || is_float($value) || is_integer($value)) {
+            return $value;
+        } elseif (is_object($value) || gettype($value) == 'object') {
+            return 'Object '.get_class($value);
+        } elseif (is_resource($value)) {
+            return 'Resource '.get_resource_type($value);
+        } elseif (is_array($value)) {
+            return 'Array of length ' . count($value);
+        } else {
+            $value = (string) $value;
+
+            if (function_exists('mb_convert_encoding')) {
+                $value = mb_convert_encoding($value, 'UTF-8', 'auto');
+            }
+
+            return $value;
+        }
+    }
+}
+
+class Raven_ReprSerializer extends Raven_Serializer
+{
+    /**
+     * Serialize a value recursively into a string-based representation
+     * of the typed PHP value.
+     */
+
+    public static function serializeValue($value)
+    {
         if ($value === null) {
             return 'null';
         } elseif ($value === false) {
@@ -62,8 +91,6 @@ class Raven_Serializer
             return 'Resource '.get_resource_type($value);
         } elseif (is_array($value)) {
             return 'Array of length ' . count($value);
-        } elseif (is_integer($value)) {
-            return (integer) $value;
         } else {
             $value = (string) $value;
 

--- a/lib/Raven/Stacktrace.php
+++ b/lib/Raven/Stacktrace.php
@@ -180,7 +180,7 @@ class Raven_Stacktrace
                         }
                     }
                 }
-                $args[$params[$i]->name] = $arg;
+                $args[$params[$i]->name] = Raven_ReprSerializer::serialize($arg);
             } else {
                 // TODO: Sentry thinks of these as context locals, so they must be named
                 // Assign the argument by number

--- a/test/Raven/Tests/SerializerTest.php
+++ b/test/Raven/Tests/SerializerTest.php
@@ -38,6 +38,97 @@ class Raven_Tests_SerializerTest extends PHPUnit_Framework_TestCase
         $this->assertEquals(1, $result);
     }
 
+    public function testFloats()
+    {
+        $input = 1.5;
+        $result = Raven_Serializer::serialize($input);
+        $this->assertTrue(is_float($result));
+        $this->assertEquals(1.5, $result);
+    }
+
+    public function testBooleans()
+    {
+        $input = true;
+        $result = Raven_Serializer::serialize($input);
+        $this->assertTrue(is_bool($result));
+        $this->assertEquals(true, $result);
+
+        $input = false;
+        $result = Raven_Serializer::serialize($input);
+        $this->assertTrue(is_bool($result));
+        $this->assertEquals(false, $result);
+    }
+
+    public function testNull()
+    {
+        $input = null;
+        $result = Raven_Serializer::serialize($input);
+        $this->assertTrue(is_null($result));
+        $this->assertEquals(null, $result);
+    }
+
+    public function testRecursionMaxDepth()
+    {
+        $input = array();
+        $input[] = &$input;
+        $result = Raven_Serializer::serialize($input, 3);
+        $this->assertEquals(array(array(array('Array of length 1'))), $result);
+    }
+}
+
+class Raven_Tests_ReprSerializerTest extends PHPUnit_Framework_TestCase
+{
+    public function testArraysAreArrays()
+    {
+        $input = array(1, 2, 3);
+        $result = Raven_Serializer::serialize($input);
+        $this->assertEquals(array('1', '2', '3'), $result);
+    }
+
+    public function testObjectsAreStrings()
+    {
+        $input = new Raven_StacktraceTestObject();
+        $result = Raven_Serializer::serialize($input);
+        $this->assertEquals('Object Raven_StacktraceTestObject', $result);
+    }
+
+    public function testIntsAreInts()
+    {
+        $input = 1;
+        $result = Raven_Serializer::serialize($input);
+        $this->assertTrue(is_integer($result));
+        $this->assertEquals(1, $result);
+    }
+
+    public function testFloats()
+    {
+        $input = 1.5;
+        $result = Raven_Serializer::serialize($input);
+        $this->assertTrue(is_string($result));
+        $this->assertEquals('1.5', $result);
+    }
+
+    public function testBooleans()
+    {
+        $input = true;
+        $result = Raven_Serializer::serialize($input);
+        $this->assertTrue(is_string($result));
+        $this->assertEquals('true', $result);
+
+        $input = false;
+        $result = Raven_Serializer::serialize($input);
+        $this->assertTrue(is_string($result));
+        $this->assertEquals('false', $result);
+    }
+
+    public function testNull()
+    {
+        $input = null;
+        $result = Raven_Serializer::serialize($input);
+        $this->assertTrue(is_string($result));
+        $this->assertEquals('null', $result);
+    }
+
     public function testRecursionMaxDepth()
     {
         $input = array();


### PR DESCRIPTION
-  Explicitly use repr-like serialization for reflection args
- Use standard JSON approach for other args