### PR TITLE
Curl async times out on first loop

### DIFF
--- a/lib/Raven/CurlHandler.php
+++ b/lib/Raven/CurlHandler.php
@@ -81,7 +81,7 @@ class Raven_CurlHandler
                 break;
             }
             usleep(10000);
-        } while ($timeout !== 0 && time() - $start > $timeout);
+        } while ($timeout !== 0 && time() - $start < $timeout);
     }
 
     // http://se2.php.net/manual/en/function.curl-multi-exec.php


### PR DESCRIPTION
Trying the async curl method from a test env requests weren't coming through...  

In Raven_CurlHandler.php adding `error_log("time minus start " . (time() - $start) . " timeout $timeout");` on line 83 (just after `usleep()`) gave the output `time minus start 0 timeout 5` immediately before exiting the loop.  Switching '>' to '<' seems to give the intended behavior.

Thanks!