### PR TITLE
Fixed bug in Raven/Stacktrace

### DIFF
--- a/lib/Raven/Stacktrace.php
+++ b/lib/Raven/Stacktrace.php
@@ -86,7 +86,7 @@ class Raven_Stacktrace
                 'filename' => $context['filename'],
                 'lineno' => (int) $context['lineno'],
                 'module' => $module,
-                'function' => $nextframe['function'],
+                'function' => (isset($nextframe['function']) ? $nextframe['function'] : null),
                 'pre_context' => $context['prefix'],
                 'context_line' => $context['line'],
                 'post_context' => $context['suffix'],


### PR DESCRIPTION
In some cases the 'function' index is not defined in the $nextframe array and my whole Laravel application crashes
